### PR TITLE
You don't need to uninstall packages to update them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,54 +3,47 @@
 This is a command line utility program to upgrade all the packages in your `package.json` to the latest version
 (potentially upgrading packages across major versions).
 
-
 ## Installation
 
-```
+```sh
 yarn add --dev yarn-upgrade-all
 ```
 
-
 ## Usage
 
-```
+```sh
 npx yarn-upgrade-all
 ```
 
-
 ## Installation globally
 
-```
+```sh
 yarn global add yarn-upgrade-all
 ```
 
 #### Installation on Windows
 
-```
+```sh
 npm install -g yarn-upgrade-all
 ```
 
 :exclamation: Don't use `yarn` to install it on Windows because there is a bug: [yarnpkg/yarn#2224](https://github.com/yarnpkg/yarn/issues/2224).
 
-
 #### Upgrade global packages
 
-```
+```sh
 yarn-upgrade-all --global
 ```
 
-
 ## How does it work?
 
-For every package in `package.json`, run `yarn remove <package-name> && yarn add [--dev|--peer] <package-name>`.
-
+For every type of dependencies in `package.json`, run `yarn add [--dev|--peer] <package-names>`.
 
 ## Why not simply `yarn upgrade --latest` ?
 
 Most of the time `yarn upgrade --latest` works. But I did meet some cases when it didn't work. I am not sure of the reason, maybe it's yarn's bug.
 
 This library is very robust because it goes the hard way.
-
 
 ## What if a package failed to install?
 
@@ -59,7 +52,6 @@ In that case, that package will be skipped and an error message will be printed.
 You need to read the error message and manually install that package.
 
 It is the recommended flow. Because if a package failed to install, most of the time, you need to manually troubleshoot the issue and fix the issue.
-
 
 ## Ignore some packages
 

--- a/index.js
+++ b/index.js
@@ -51,28 +51,29 @@ let ignorePkgs = []
 if (packageJson['yarn-upgrade-all'] && packageJson['yarn-upgrade-all'].ignore) {
   ignorePkgs = packageJson['yarn-upgrade-all'].ignore
 }
+
+/**
+ * @Gorniaky - you don't need to uninstall packages to update them. Now updates much faster.
+ */
 for (const element of ['dependencies', 'devDependencies', 'peerDependencies']) {
-  if (packageJson[element]) {
-    const option = options[element]
-    const packages = Object.keys(packageJson[element])
-    for (const pkg of packages) {
-      if (ignorePkgs.indexOf(pkg) > -1) {
-        continue
-      }
-      if (element === 'peerDependencies' && packageJson.devDependencies && packageJson.devDependencies[pkg]) {
-        continue
-      }
-      let command = `yarn${global} remove ${pkg} && yarn${global} add${option} ${pkg} ${params}`
-      if (element === 'devDependencies' && packageJson.peerDependencies && packageJson.peerDependencies[pkg]) {
-        command = `yarn${global} remove ${pkg} && yarn${global} add --peer ${pkg} ${params}&& yarn${global} add --dev ${pkg} ${params}`
-      }
-      try {
-        logInfo(command)
-        childProcess.execSync(command, { stdio: [] })
-        logSuccess(command)
-      } catch (e) {
-        logError(`${command} - ${e}`)
-      }
-    }
+  if (!packageJson[element]) continue
+  const option = options[element]
+  const packages = Object.keys(packageJson[element])
+  let command = `yarn${global} add${option}`
+
+  for (const pkg of packages) {
+    if (ignorePkgs.indexOf(pkg) > -1) continue
+
+    command = `${command} ${pkg}`
+  }
+  command = `${command} ${params}`
+
+  try {
+    logInfo(command)
+    childProcess.execSync(command, { stdio: [] })
+    logSuccess(command)
+  } catch (e) {
+    logError(`${command} - ${e}`)
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "yarn-upgrade-all",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "This is a command line utility program to upgrade all the packages in your package.json to the latest version (potentially upgrading packages across major versions).",
   "bin": {
     "yarn-upgrade-all": "./index.js"
   },
   "repository": "git@github.com:tylerlong/yarn-upgrade-all.git",
   "author": "Tyler Long <tyler4long@gmail.com>",
+  "contributors": [{ "email": "hwss.s2@gmail.com", "name": "Gorniaky", "url": "http://github.com/Gorniaky" }],
   "license": "MIT",
   "scripts": {
     "upgrade": "node index.js"


### PR DESCRIPTION
Uninstalling and reinstalling packages takes time.

I did some testing and came to the conclusion that it is not necessary to uninstall the packages and that using the name of all the packages in the `yarn add` command is simpler and much faster.